### PR TITLE
V0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The current tool set includes the following tools:
 1. docker-compose : the docker-compose client to spin up docker containers using its specification
 1. kubectl : the Kubernetes API client
 1. helm : the Kubernetes deployment packaging tool
-1. cloud cli's : aws, gcloud, azure
+1. cloud cli's : aws, gcloud, azure (**note:** uses the cli 2.0 container)
 1. ruby aws-sdk, google-cloud, azure
 1. ~~chef inspec : for IT Security and Compliance as Code~~ waiting for AWS SDK 3 support
 1. ruby terraforming : used to initialize terraform projects from existing infrastructure

--- a/az
+++ b/az
@@ -1,0 +1,5 @@
+#!/bin/sh
+DOCKER_IMAGE='azuresdk/azure-cli-python'
+DOCKER_TAG='latest'
+
+docker run -ti --rm -v ${AZURE_CONFIG}:/root/.azure ${DOCKER_IMAGE}:${DOCKER_TAG} az $@

--- a/multi-tool
+++ b/multi-tool
@@ -15,8 +15,8 @@
 # (AZURE,AWS,GOOGLE,KUBE,HELM)_CONFIG specify the respective config directories
 #
 
-MULTI_TOOL_TAG=${TAG:-v0.5.0}
-DOCKER_IMAGE="multi-tool:$TAG"
+MULTI_TOOL_TAG=${MULTI_TOOL_TAG:-v0.5.0}
+DOCKER_IMAGE="multi-tool:$MULTI_TOOL_TAG"
 
 # Update this if you're using a private docker registry
 REGISTRY="quay.io/leopoldodonnell/"

--- a/multi-tool
+++ b/multi-tool
@@ -9,19 +9,34 @@
 #   -d : debug mode. Drop into the container using bash as an interactive entry point
 #   -m : use the minikube docker enviroment to simplify local work
 #
+# Available environment override variables:
+#
+# MULTI_TOOL_TAG = specifies the tag to use for multi-tool
+# (AZURE,AWS,GOOGLE,KUBE,HELM)_CONFIG specify the respective config directories
+#
 
-DOCKER_IMAGE="multi-tool:v0.4.0"
+MULTI_TOOL_TAG=${TAG:-v0.5.0}
+DOCKER_IMAGE="multi-tool:$TAG"
 
 # Update this if you're using a private docker registry
 REGISTRY="quay.io/leopoldodonnell/"
 
-VOLUMES="-v $HOME/.aws:/mthome/.aws \
-        -v $HOME/.config:/mthome/.config \
-        -v $HOME/.config:/mthome/.azure \
+# Provide defaults with environment variable overrides for config directories
+AZURE_CONFIG=${AZURE_CONFIG:-$HOME/.azure}
+AWS_CONFIG=${AWS_CONFIG:-$HOME/.aws}
+GOOGLE_CONFIG=${GOOGLE_CONFIG:-$HOME/.config}
+KUBE_CONFIG=${KUBE_CONFIG:-$HOME/.kube}
+MINIKUBE_CONFIG=${MINIKUBE_CONFIG:-$HOME/.minikube}
+HELM_CONFIG=${HELM_CONFIG:-$HOME/.helm}
+
+
+VOLUMES="-v $AWS_CONFIG:/mthome/.aws \
+        -v $GOOGLE_CONFIG:/mthome/.config \
+        -e AZURE_CONFIG=$AZURE_CONFIG \
         -v ${PWD}:/share \
-        -v $HOME/.kube:/mthome/.kube \
-        -v $HOME/.minikube:$HOME/.minikube \
-        -v $HOME/.helm:/mthome/.helm \
+        -v $KUBE_CONFIG:/mthome/.kube \
+        -v $MINIKUBE_CONFIG:$HOME/.minikube \
+        -v $HELM_CONFIG:/mthome/.helm \
         -v /var/run/docker.sock:/var/run/docker.sock"
 
 opt_count=0
@@ -63,7 +78,7 @@ done
 # get rid of options passed the to script and not passed onto the container
 shift $opt_count
 
-docker run --rm \
+docker run -ti --rm \
   ${VOLUMES} \
   ${MINIKUBE_ENV} \
   ${DEBUG} \


### PR DESCRIPTION
Update to Azure CLI 2.0

- the previous version of multi-tool embedded the nodejs version of the Azure CLI which would not support some of the newer resources in Azure. This update uses the 'latest' version of the python version of the Azure CLI known as 2.0

- the Azure CLI depends on python 3 while the current version of the AWS cli depends on python 2.7, so a docker-in-docker approach is applied to run the `az` command.
